### PR TITLE
feat: table header of inner of simple dict

### DIFF
--- a/packages/form/src/extensions/table.vue
+++ b/packages/form/src/extensions/table.vue
@@ -19,7 +19,7 @@
             {{ tt(schema.sKey?.meta.description) || t('entry.key') }}
           </th>
           <th v-for="([key, schema]) in columns" :key="key">
-            <span>{{ key === null ? t('entry.value') : tt(schema.meta.description) || key }}</span>
+            <span>{{ tt(schema.meta.description) || key || t('entry.value') }}</span>
             <k-badge :type="type" v-for="{ text, type } in schema.meta.badges || []">
               {{ t('badge.' + text) }}
             </k-badge>


### PR DESCRIPTION
对于 `Dict<string>` 类型与其对应的 `Schema.dict(Schema.string().description('...'))`
允许其在 `role('table')` 视图下显示自定义描述作为值列的表头而非「值」